### PR TITLE
[CCXDEV-6957] Add the version_info rule

### DIFF
--- a/ccx_rules_ocm/version_info.py
+++ b/ccx_rules_ocm/version_info.py
@@ -1,0 +1,28 @@
+"""
+Get the cluster version.
+======================================================
+
+Trigger conditions:
+    - always
+
+* Author     : Juan Díaz <jdiazsua@redhat.com>
+* JIRA card  : https://issues.redhat.com/browse/CCXDEV-6957
+"""
+from ccx_ocp_core.models import Version
+from insights.core.plugins import make_info
+from insights.core.plugins import rule
+
+
+INFO_KEY = "CLUSTER_VERSION_INFO"
+
+LINKS = {}
+
+CONTENT = """
+Cluster Version: {{version}}
+
+""".strip()
+
+
+@rule(Version, links=LINKS)
+def report(version):
+    return make_info(INFO_KEY, version=version.current)


### PR DESCRIPTION
I've tested it with the `ccx-data-pipeline` and it's working as expected:

```json
{
  "OrgID": 1,
  "AccountNumber": 1,
  "ClusterName": null,
  "Report": {
    "system": {
      "metadata": {},
      "hostname": null
    },
    "reports": [
      {
        "rule_id": "tutorial_rule|TUTORIAL_ERROR",
        ...
      },
      {
        "rule_id": "ocp_version_end_of_life|OCP4X_BEYOND_EOL",
       ...
      },
      {
        "rule_id": "bug_1832986|BUGZILLA_BUG_1832986",
       ...
      },
    ],
    "fingerprints": [],
    "info": [
      {
        "info_id": "version_info|CLUSTER_VERSION_INFO",
        "component": "ccx_rules_ocm.version_info.report",
        "type": "info",
        "key": "CLUSTER_VERSION_INFO",
        "details": {
          "version": "4.4.6",
          "type": "info",
          "info_key": "CLUSTER_VERSION_INFO"
        },
        "tags": [],
        "links": {}
      },
      {
        "info_id": "cluster_id|GRAFANA_LINK",
        ...
      }
    ],
    "analysis_metadata": {
      "start": "2022-04-22T07:10:50.621941+00:00",
      "finish": "2022-04-22T07:10:50.756156+00:00",
      "execution_context": "ccx_ocp_core.context.InsightsOperatorContext",
      "plugin_sets": {
        "insights-core": {
          "version": "insights-core-3.0.271-1",
          "commit": "placeholder"
        },
        "ccx_rules_ocp": {
          "version": "ccx_rules_ocp-2022.4.12-1",
          "commit": null
        },
        "ccx_ocp_core": {
          "version": "ccx_ocp_core-2022.4.18-1",
          "commit": null
        }
      }
    }
  },
  "LastChecked": "2022-04-22T07:10:50.522747805Z",
  "Version": 2,
  "RequestId": "90e02dd06d7c/3RPA3etZig-000002"
}

```

Closes [CCXDEV-6957](https://issues.redhat.com/browse/CCXDEV-6957).